### PR TITLE
check file extension when looking at package-declared "main"

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function bowerRequire(moduleName) {
       var mainModule;
       var pkgMeta = module.pkgMeta;
       if (pkgMeta && pkgMeta.main) {
-        mainModule = Array.isArray(pkgMeta.main) ? pkgMeta.main[0] : pkgMeta.main;
+        mainModule = Array.isArray(pkgMeta.main) ? pkgMeta.main.filter(function (file) { return /\.js$/.test(file); })[0] : pkgMeta.main;
       } else {
         // if 'main' wasn't specified by this component, let's try
         // guessing that the main file is moduleName.js


### PR DESCRIPTION
This allows it to work with packages like `bootstrap`.
`debowerify` already does this.

By the way, I think `bower-resolve` should either be used by `debowerify`, or be a part of it.
What's your thought on this?
